### PR TITLE
Add Composer and modman integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for modman and Composer
 
 ## [1.1.0] - 2017-07-21
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,16 +10,39 @@ Following two things are overridden:
 **NOTE:** Running Chuvisco_CatalogRuleFix requires you to run the cronjobs of Magento. If they are not set up, please 
 do so by following the [docs](http://devdocs.magento.com/guides/m1x/install/installing_install.html#install-cron).
 
+This module can be installed in various ways: via modman, Composer or manually.
+Currently installation via Magento Connect is not supported.
+
+#### Modman
+
+1. Install [modman](https://github.com/colinmollenhour/modman)
+2. Execute the following command from your Magento installation folder:
+```sh
+modman clone https://github.com/Chuvisco88/Chuvisco_CatalogRuleFix.git
+```
+
+### Composer
+
+1. Install [Composer](http://getcomposer.org/download/)
+2. Install [Magento Composer](https://github.com/magento-hackathon/magento-composer-installer)
+3. Add the repository to the Composer configuration of your project:
+```sh
+composer config repositories.catalogrulefix vcs https://github.com/Chuvisco88/Chuvisco_CatalogRuleFix.git
+```
+4. Add the package to the Composer configuration of your project:
+```sh
+composer require "chuvisco/catalog-rule-fix"
+```
+
+### Manually
+
 [Download the zip or tar.gz file](https://github.com/Chuvisco88/Chuvisco_CatalogRuleFix/releases) and extract it into your project webroot.
  
- Currently installation via composer or Magento Connect is not supported.
-
 ## Changelog
 
 The changelog is [in another castle](CHANGELOG.md).
 
 ## Roadmap
-- Composer and Modman integration
 - Tests and TravisCI integration
 - Magento Connect integration
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "chuvisco/catalog-rule-fix",
+    "description": "Fix timezone issues in the Mage_CatalogRule module.",
+    "type": "magento-module",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Fabian Schweizer"
+        }
+    ],
+    "suggest": {
+        "magento-hackathon/magento-composer-installer": "Allows to manage this package as a dependency"
+    }
+}

--- a/modman
+++ b/modman
@@ -1,0 +1,2 @@
+app/etc/modules/Chuvisco_CatalogRuleFix.xml         app/etc/modules/Chuvisco_CatalogRuleFix.xml
+app/code/community/Chuvisco/CatalogRuleFix/         app/code/community/Chuvisco/CatalogRuleFix/


### PR DESCRIPTION
This PR adds Composer and modman integration.

Notes on the Composer integration:
* The Composer integration uses the modman file to map packages files onto the Magento source.
* When this package is registered using a global Composer repository (the [Firegento Magento Module Composer Repository](https://packages.firegento.com/) or [Packagist](https://packagist.org/)), the Composer instructions can be simplified (the repository doesn't have to be added to your project anymore).

Can you please have a look at this?

Thanks!

Aad