### PR TITLE
Add version in composer.json to be stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Fix timezone issues in the Mage_CatalogRule module.",
     "type": "magento-module",
     "license": "MIT",
+    "version": "1.1.1",
     "authors": [
         {
             "name": "Fabian Schweizer"


### PR DESCRIPTION
I added the version `1.1.1` in `composer.json` and push a tag `v1.1.1` in order to be able to add the module if I have the line `"minimum-stability": "stable"` in my project